### PR TITLE
OSGI compatibility for Wicketstuff Merged Resources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>at.molindo</groupId>
 	<artifactId>wicketstuff-merged-resources</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 	<version>3.1-SNAPSHOT</version>
 	<name>Wicket Merged Resources</name>
 	<description>
@@ -92,6 +92,31 @@
 			<artifactId>jcl-over-slf4j</artifactId>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<!--  Creates a correct MANIFEST.MF to help with OSGI -->
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>1.4.0</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-SymbolicName>${project.groupId}</Bundle-SymbolicName>
+						<Bundle-Name>${project.artifactId}</Bundle-Name>
+						<Bundle-Version>${project.version}</Bundle-Version>
+						<Export-Package>org.wicketstuff.mergedresources.*;
+						at.molindo.thirdparty.com.yahoo.platform.yui.compressor
+						</Export-Package>
+						<Import-Package>
+							*;resolution:=optional
+			        </Import-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<properties>
 		<wicket.version>1.4.13</wicket.version>


### PR DESCRIPTION
This uses http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html to generate a MANIFEST.MF in the generated jar. This makes it possible to use this jar directly as a bundle in OSGI-enabled servers (like DM-server or Virgo).
