### PR TITLE
Double encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -131,6 +132,19 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.easymock</groupId>
+			<artifactId>easymock</artifactId>
+			<version>3.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.4</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategy.java
+++ b/src/main/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategy.java
@@ -53,10 +53,14 @@ public class RemoteHostUrlCodingStrategy implements IRequestTargetUrlCodingStrat
 		_strategy = newStrategy(mountPath, _key);
 
 		if (root != null) {
+			if (root.getQuery() != null) {
+				throw new IllegalArgumentException("root URL must not contain a query: " + root);
+			}
+
 			_protocol = root.getProtocol();
 			_port = root.getPort();
 			_host = root.getHost();
-			_path = StringUtils.trailing(root.getFile(), "/");
+			_path = StringUtils.trailing(root.getPath(), "/");
 		} else {
 			_port = null;
 			_host = _protocol = _path = null;

--- a/src/main/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategy.java
+++ b/src/main/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategy.java
@@ -15,8 +15,6 @@
  */
 package org.wicketstuff.mergedresources.urlcoding;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,8 +33,6 @@ import org.apache.wicket.request.target.resource.SharedResourceRequestTarget;
 import at.molindo.utils.data.StringUtils;
 
 public class RemoteHostUrlCodingStrategy implements IRequestTargetUrlCodingStrategy, IMountableRequestTargetUrlCodingStrategy {
-
-	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(RemoteHostUrlCodingStrategy.class);
 
 	private final AbstractRequestTargetUrlCodingStrategy _strategy;
 	private final String _key;
@@ -118,20 +114,19 @@ public class RemoteHostUrlCodingStrategy implements IRequestTargetUrlCodingStrat
 			}
 		}
 
-		try {
-
-			final URI uri = new URI(protocol, null, _host, port == null ? -1 : port, _path
-					+ StringUtils.stripLeading(encoded.toString(), "/"), null, null);
-
-			if (_useSchemelessUrl) {
-				return uri.getRawSchemeSpecificPart();
-			} else {
-				return uri.toString();
-			}
-		} catch (final URISyntaxException e) {
-			log.error("failed to build URL, balling back to default", e);
-			return encoded;
+		final StringBuilder buf = new StringBuilder();
+		if (!_useSchemelessUrl) {
+			buf.append(protocol).append(":");
 		}
+		buf.append("//");
+		buf.append(_host);
+		if (port != null) {
+			buf.append(":").append(port);
+		}
+		buf.append(_path);
+		buf.append(StringUtils.stripLeading(encoded.toString(), "/"));
+
+		return buf.toString();
 	}
 
 	@Override

--- a/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest$ImagePanel.html
+++ b/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest$ImagePanel.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket>
+<wicket:panel>
+<img wicket:id="img" />
+</wicket:panel>
+</html>

--- a/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest-expected-encoding.html
+++ b/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest-expected-encoding.html
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<html>
+<body>
+  <span>
+<img src="http://cdn.example.com/files/images/foo%2Fbar/image.png"/>
+</span>
+</body>
+</html>

--- a/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest.java
+++ b/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest.java
@@ -31,6 +31,11 @@ public class RemoteHostUrlCodingStrategyTest {
 
 	private static final ResourceReference REF = new ResourceReference(RemoteHostUrlCodingStrategyTest.class, "image");
 
+	@Test(expected = IllegalArgumentException.class)
+	public void noQuery() throws Exception {
+		new RemoteHostUrlCodingStrategy(new URL("http://cdn.example.com/files?test"), "/", REF);
+	}
+
 	@Test
 	public void encoding() throws Exception {
 		final URL url = new URL("http://cdn.example.com/files");

--- a/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest.java
+++ b/src/test/java/org/wicketstuff/mergedresources/urlcoding/RemoteHostUrlCodingStrategyTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 Molindo GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.mergedresources.urlcoding;
+
+import java.net.URL;
+
+import org.apache.wicket.PageParameters;
+import org.apache.wicket.ResourceReference;
+import org.apache.wicket.markup.html.image.Image;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.request.target.coding.AbstractRequestTargetUrlCodingStrategy;
+import org.apache.wicket.request.target.coding.IndexedSharedResourceCodingStrategy;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.Test;
+import org.wicketstuff.mergedresources.AbstractTestApplication;
+
+public class RemoteHostUrlCodingStrategyTest {
+
+	private static final ResourceReference REF = new ResourceReference(RemoteHostUrlCodingStrategyTest.class, "image");
+
+	@Test
+	public void encoding() throws Exception {
+		final URL url = new URL("http://cdn.example.com/files");
+		final String path = "images";
+
+		final WicketTester tester = new WicketTester(new AbstractTestApplication() {
+
+			@Override
+			protected void mountResources() {
+
+				mount(new RemoteHostUrlCodingStrategy(url, path, REF) {
+					@Override
+					protected AbstractRequestTargetUrlCodingStrategy newStrategy(final String mountPath, final String sharedResourceKey) {
+						return new IndexedSharedResourceCodingStrategy(mountPath, sharedResourceKey);
+					}
+				});
+			}
+		});
+
+		tester.startPanel(ImagePanel.class);
+
+		tester.assertResultPage(RemoteHostResourceMountTest.class, "RemoteHostUrlCodingStrategyTest-expected-encoding.html");
+
+	}
+
+	public static class ImagePanel extends Panel {
+
+		public ImagePanel(final String id) {
+			super(id);
+			add(new Image("img", REF, new PageParameters("0=foo/bar,1=image.png")));
+		}
+
+	}
+}


### PR DESCRIPTION
* fixed double encoding of paths in RemoteHostUrlCodingStrategy
* disallow queries in root URL

`new URI(..)` encodes an already encoded path, therefore `/` became `%252F` instead of `%2F`